### PR TITLE
Temporarily revert loading dependencies

### DIFF
--- a/diffblue-base.json
+++ b/diffblue-base.json
@@ -1,22 +1,4 @@
 {
   "phaseBase": {
-    "javaVersion": 6,
-    "preferDepsJar": true,
-    "context-include": [
-      "com.google.gson.",
-      "com.diffblue.annotation.",
-      "java.",
-      "org.cprover.",
-      "org.slf4j.helpers.MarkerIgnoringBase",
-      "org.slf4j.helpers.NamedLoggerBase",
-      "org.slf4j.helpers.NOPLogger",
-      "org.slf4j.ILoggerFactory",
-      "org.slf4j.Logger",
-      "org.slf4j.LoggerFactory",
-      "org.slf4j.Marker",
-      "sun.misc.",
-      "sun.nio.cs.",
-      "sun.util."
-    ]
-  }
+    "javaVersion": 6
 }


### PR DESCRIPTION
This reverts the recent change
`Update settings to load fat jar but not analyse dependencies`
(https://github.com/Diffblue-benchmarks/gson/pull/5/commits/323a7c15c82ce57661d064d7ef342d2a6ef15ad1)
so that we can properly investigate the effect of this change on dashboard. Currently we cannot access the detailed JaCoCo logs because the VMs from the time this change was originally made no longer exist. After a dashboard run has been triggered with the reverted change, the change should immediately be restored in a follow-up PR.