### PR TITLE
Revert "Temporarily revert loading dependencies"

### DIFF
--- a/diffblue-base.json
+++ b/diffblue-base.json
@@ -1,4 +1,22 @@
 {
   "phaseBase": {
-    "javaVersion": 6
+    "javaVersion": 6,
+    "preferDepsJar": true,
+    "context-include": [
+      "com.google.gson.",
+      "com.diffblue.annotation.",
+      "java.",
+      "org.cprover.",
+      "org.slf4j.helpers.MarkerIgnoringBase",
+      "org.slf4j.helpers.NamedLoggerBase",
+      "org.slf4j.helpers.NOPLogger",
+      "org.slf4j.ILoggerFactory",
+      "org.slf4j.Logger",
+      "org.slf4j.LoggerFactory",
+      "org.slf4j.Marker",
+      "sun.misc.",
+      "sun.nio.cs.",
+      "sun.util."
+    ]
+  }
 }


### PR DESCRIPTION
Reverting the revert commit, i.e. restoring the loading of dependencies on this benchmark.

Commit generated using `git revert d8174060e122ff0f1d879d4afe3824c763b0f8b7`.